### PR TITLE
Handle the 'field of activity' value with single data correctly.

### DIFF
--- a/asset/js/uri-dereferencer-services.js
+++ b/asset/js/uri-dereferencer-services.js
@@ -310,7 +310,11 @@ UriDereferencer.addService({
             data.set('Name type', json['nameType']);
         }
         if (UriDereferencer.isset(() => json['fieldOfActivity']['data'])) {
-            for (let fields of json['fieldOfActivity']['data']) {
+            let retrievedData = json['fieldOfActivity']['data'];
+            if (!Array.isArray(retrievedData)) {
+                retrievedData = [retrievedData];
+            }
+            for (let fields of retrievedData) {
                 if ('LC' === fields['sources']['s']) {
                     data.set('Field of activity', fields['text']);
                 }


### PR DESCRIPTION
Some VIAF record has only a single data of 'field of activity'. For example, get http://viaf.org/viaf/76350116/viaf.json and you'll get:
> (...)
>  "fieldOfActivity": {"data": {
>    "text": "일본문학",
>    "sources": {"s": "KRNLK"}
>  }},
> (...)

The current implementation of UriDereferencer failed to handle this. This patch fixes this issue.
