### PR TITLE
fix and expand geonames uri dereferencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ a handful of services:
 - [OCLC FAST](http://fast.oclc.org/)
 - [RDA Value Vocabularies](http://www.rdaregistry.info/termList/)
 - [Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page)
+- [Gemeentegeschiedenis](https://www.gemeentegeschiedenis.nl/)
 
 You can create your own linked data service objects by writing them against the
 following interface and adding them to the global `UriDereferencer` object.

--- a/asset/js/uri-dereferencer-services.js
+++ b/asset/js/uri-dereferencer-services.js
@@ -450,3 +450,37 @@ UriDereferencer.addService({
         return uri.match(/^https?:\/\/(?:www\.)?rdaregistry\.info\/termList\/(.+)\/#?(.+)$/);
     }
 });
+UriDereferencer.addService({
+    getName() {
+        // https://www.gemeentegeschiedenis.nl/
+        return 'Gemeentegeschiedenis'; // Dutch municipal history
+    },
+    getOptions() {
+		return {};
+    },
+    isMatch(uri) {
+        return (null !== this.getMatch(uri));
+    },
+    getResourceUrl(uri) {
+        const match = this.getMatch(uri);
+        return `https://www.gemeentegeschiedenis.nl/gemeentenaam/json/${match[1]}`;
+    },
+    getMarkup(uri, text) {
+        const match = this.getMatch(uri);
+        const json = JSON.parse(text);
+        const data = new Map();		
+		Object.keys(json).forEach(function(key) {
+			if (key!="geometries" && key!="uri" && json[key]!="null" && typeof json[key] === 'string') {
+				data.set(key, json[key]);
+			}
+		})
+        let dataMarkup = '';
+        for (let [key, value] of data) {
+            dataMarkup += `<dt>${key}</dt><dd>${value}</dd>`
+        }
+        return `<dl>${dataMarkup}</dl>`;
+    },
+    getMatch(uri) {
+        return uri.match(/^https?:\/\/www\.gemeentegeschiedenis\.nl\/gemeentenaam\/(.*)/);
+    }
+});

--- a/asset/js/uri-dereferencer-services.js
+++ b/asset/js/uri-dereferencer-services.js
@@ -230,7 +230,9 @@ UriDereferencer.addService({
         return 'Geonames';
     },
     getOptions() {
-        return {};
+        // Must use the proxy because responses sent from Geonames don't
+        // include an Access-Control-Allow-Origin header.
+        return {'useProxy': true};
     },
     isMatch(uri) {
         return (null !== this.getMatch(uri));
@@ -259,7 +261,7 @@ UriDereferencer.addService({
         return `<dl>${dataMarkup}</dl>`;
     },
     getMatch(uri) {
-        return uri.match(/^https?:\/\/www\.geonames\.org\/(.+?)(?:\/.+\.html)?$/);
+      return uri.match(/^https?:\/\/[sw]w[sw]\.geonames\.org\/(.+?)(?:\/.+\.html)?$/);
     },
     getNodeText(xmlDoc, xpathExpression) {
         const namespaceResolver = function(prefix) {


### PR DESCRIPTION
Dereferencing of Geonames URIs need a proxy (CORS).
Geonames URIs have the form. https://sws.geonames.org/2755420/, the regexp now allows for this.
Added gemeentegeschiedenis.nl service (Dutch municipal history).