### PR TITLE
Refactor toggle/fetch JS.

### DIFF
--- a/asset/css/uri-dereferencer.css
+++ b/asset/css/uri-dereferencer.css
@@ -18,4 +18,9 @@ a.uri-dereferencer-fetch {
 
 .uri-dereferencer-markup {
   width: 100%;
+  display: none;
+}
+
+.uri-dereferencer-markup.open {
+  display: inline-flex;
 }

--- a/asset/js/uri-dereferencer-module.js
+++ b/asset/js/uri-dereferencer-module.js
@@ -14,46 +14,35 @@ document.addEventListener('DOMContentLoaded', function(event) {
         // The toggle button.
         const toggleButton = document.createElement('a');
         toggleButton.className = 'uri-dereferencer-toggle';
-        toggleButton.href = '#';
-        toggleButton.innerHTML = '[–]';
         toggleButton.setAttribute('aria-controls', containerId);
-        toggleButton.setAttribute('aria-expanded', 'false');
-        toggleButton.style.display = 'none';
-        toggleButton.onclick = function(e) {
+        toggleButton.href = '#';
+        toggleButton.innerHTML = '[+]';
+        loading = document.createElement('i');
+        loading.className = 'loading';
+        toggleButton.onclick = async function(e) {
             e.preventDefault();
-            if ('none' === container.style.display) {
-                container.style.display = 'inline-flex';
-                container.focus();
-                this.innerHTML = '[–]';
-                this.setAttribute('aria-expanded', 'true');
+            if (container.classList.contains('open')) {
+                container.classList.remove('open');
+                toggleButton.innerHTML = '[+]';
+                toggleButton.setAttribute('aria-expanded', 'false');
             } else {
-                container.style.display = 'none';
-                this.innerHTML = '[+]';
-                this.setAttribute('aria-expanded', 'false');
+                container.classList.add('open');
+                container.focus();
+                toggleButton.innerHTML = '[–]';
+                toggleButton.setAttribute('aria-expanded', 'true');
+            }
+
+            // Only fetch the first time.
+            if (toggleButton.classList.contains('fetched') == false) {
+                container.innerHTML = loading.outerHTML;
+                container.innerHTML = await UriDereferencer.dereference(
+                    uriValue.href,
+                    uriValue.closest('.value').getAttribute('lang')
+                );
+                toggleButton.classList.add('fetched');
             }
         };
 
-        // The fetch button.
-        const fetchButton = document.createElement('a');
-        fetchButton.className = 'uri-dereferencer-fetch';
-        fetchButton.href = '#';
-        fetchButton.innerHTML = '[+]';
-        loading = document.createElement('i');
-        loading.className = 'loading';
-        fetchButton.onclick = async function(e) {
-            e.preventDefault();
-            container.innerHTML = loading.outerHTML;
-            container.innerHTML = await UriDereferencer.dereference(
-                uriValue.href,
-                uriValue.closest('.value').getAttribute('lang')
-            );
-            container.focus();
-            this.style.display = 'none';
-            toggleButton.style.display = 'inline-flex';
-            toggleButton.setAttribute('aria-expanded', 'true');
-        };
-
-        uriValue.parentNode.prepend(fetchButton);
         uriValue.parentNode.prepend(toggleButton);
         uriValue.parentNode.append(container);
     }


### PR DESCRIPTION
**Manage dereferencer content visibility with css class instead of inline styles. (Addresses omeka/omeka-s#2249)**

Previously, the `div.uri-dereferencer-markup` is visible on load, even if empty. This causes some themes to display empty containers, creating awkward extra space or empty boxes in some themes. Now the CSS sets this container to `display: none` by default, then applies visibility by adding the `.open` CSS class. 

**Condense fetch and toggle into single button.**

A single button toggles the content and only fetches dereferencer content on the first click, reducing the amount of markup added to the page.